### PR TITLE
The default value for the dqm_globallock is set to True.

### DIFF
--- a/etc/hltd.conf
+++ b/etc/hltd.conf
@@ -32,7 +32,7 @@ resource_use_fraction = 0.5
 [DQM]
 dqm_machine = False
 dqm_resource_base = /etc/appliance/dqm_resources
-dqm_globallock = False
+dqm_globallock = True
 
 [Recovery]
 process_restart_delay_sec = 5.


### PR DESCRIPTION
The DQM had been testing the prod system with the DQM function manager for some time and it behaves really well. This is why we've decided to set the default value for globallock to True.