### PR TITLE
Fully dereference symbolic link before the start of the dqm run.

### DIFF
--- a/scripts/startDqmRun.sh
+++ b/scripts/startDqmRun.sh
@@ -13,9 +13,10 @@ cd $1
 cd base
 source cmsset_default.sh >> $logname
 cd $1
-cd current
+# fully dereference 'current' symbolic link 
+cd `readlink -f current`
 pwd >> $logname 2>&1
 eval `scram runtime -sh`;
 cd $3;
 pwd >> $logname 2>&1
-exec esMonitoring.py -z $lognamez cmsRun `readlink $6` runInputDir=$5 runNumber=$4 $7 $8 >> $logname 2>&1
+exec esMonitoring.py -z $lognamez cmsRun `readlink -f $6` runInputDir=$5 runNumber=$4 $7 $8 >> $logname 2>&1


### PR DESCRIPTION
This solves the mysterious crash of cmssw which happens if you
update that symbolic link on the fly.

Not only this makes our updates easier, but also makes things clearier
(full path to project area will appear in the logs, not just the symbolic link).