### PR TITLE
Fix usage of frontier client environment variables

### DIFF
--- a/scripts/startDqmRun.sh
+++ b/scripts/startDqmRun.sh
@@ -19,4 +19,5 @@ pwd >> $logname 2>&1
 eval `scram runtime -sh`;
 cd $3;
 pwd >> $logname 2>&1
+export FRONTIER_LOG_LEVEL="warning"
 exec esMonitoring.py -z $lognamez cmsRun `readlink -f $6` runInputDir=$5 runNumber=$4 $7 $8 >> $logname 2>&1

--- a/scripts/startRun.sh
+++ b/scripts/startRun.sh
@@ -13,7 +13,6 @@ pwd >> $logname 2>&1
 eval `scram runtime -sh`;
 cd $4;
 export FRONTIER_LOG_LEVEL="warning"
-export FRONTIER_LOG_FILE=""
 export FFF_EMPTYLSMODE="true"
 type -P cmsRun &>/dev/null || (sleep 2;exit 127)
 exec cmsRun $6 "transferMode="$7 "runNumber="$8 "buBaseDir="$9 "dataDir"=${10} "numThreads="${11} "numFwkStreams"=${12} >> $logname 2>&1


### PR DESCRIPTION
Removed initialisation of `FRONTIER_LOG_FILE` environment variable with empty string.
Initialising the `FRONTIER_LOG_FILE` environment variable with empty string is a bug in the most recent versions of the frontier client: you get an error message like:

````
Cannot open log file . Log is disabled.
````

Hence, you have no log messages at all. I checked this both online on the DQM playback and on Hilton, and offline with a recent CMSSW.
By removing the environment variable, the log messages go to `stdout`, and they are captured in the log file.

Added frontier log level environment variable in DQM script, in order to allow frontier client logs (replicating HLT startup script).